### PR TITLE
Allow to cancell start sandbox stage

### DIFF
--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/ColonyBaseTask.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/ColonyBaseTask.kt
@@ -5,7 +5,7 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 
 
 interface ColonyBaseTask : Task{
-    fun addToObjectToStageContext(stage: StageExecution, key: String?, value: Any?) {
+    fun addObjectToStageContext(stage: StageExecution, key: String?, value: Any?) {
         stage.context[key] = value
     }
 

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/stages/ColonyStartSandboxStage.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/stages/ColonyStartSandboxStage.kt
@@ -1,15 +1,15 @@
 package com.quali.colony.plugins.spinnaker
 
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+
 import com.netflix.spinnaker.orca.api.pipeline.graph.TaskNode
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.quali.colony.plugins.spinnaker.tasks.ColonyStartSandboxTask
 import com.quali.colony.plugins.spinnaker.tasks.ColonyVerifySandboxIsReadyTask
 import org.pf4j.Extension
 
-
 @Extension
-class ColonyStartSandboxStage : StageDefinitionBuilder {
+class ColonyStartSandboxStage : StageDefinitionBuilder{
 
     override fun taskGraph(stage: StageExecution, builder: TaskNode.Builder) {
         builder.withTask("startSandbox", ColonyStartSandboxTask::class.java)


### PR DESCRIPTION
- Blocking loop logic was re-written by internal mechanism of Spinnaker -- RetryableTask
- Now user can cancel pipeline on StartSandbox stage and it will also end the launching sandbox