### PR TITLE
Configurable token

### DIFF
--- a/colony-deck/src/ColonyEndSandboxStageConfig.tsx
+++ b/colony-deck/src/ColonyEndSandboxStageConfig.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import {
-  FormikFormField,
-  FormikStageConfig,
-  HelpField,
-  IStageConfigProps,
-  TextInput,
+    FormikFormField,
+    FormikStageConfig,
+    HelpField,
+    IStageConfigProps,
+    TextInput,
 } from '@spinnaker/core';
 
 import './ColonyEndSandboxStage.less';
@@ -33,7 +33,7 @@ export function ColonyEndSandboxStageConfig(props: IStageConfigProps) {
           <FormikFormField
               name="token"
               label="Token"
-              input={(props) => <TextInput {...props} />}
+              input={(props) => <TextInput type="password" {...props} />}
               help={<HelpField id="quali.colonyStartSandboxStage.token"/>}
           />
           </>

--- a/colony-deck/src/ColonyEndSandboxStageConfig.tsx
+++ b/colony-deck/src/ColonyEndSandboxStageConfig.tsx
@@ -1,20 +1,11 @@
 import React from 'react';
 
 import {
-  ExecutionDetailsSection,
-  ExecutionDetailsTasks,
   FormikFormField,
   FormikStageConfig,
-  FormValidator,
-  HelpContentsRegistry,
   HelpField,
-  IExecutionDetailsSectionProps,
-  IStage,
   IStageConfigProps,
-  IStageTypeConfig,
-  NumberInput,
   TextInput,
-  Validators,
 } from '@spinnaker/core';
 
 import './ColonyEndSandboxStage.less';
@@ -38,6 +29,12 @@ export function ColonyEndSandboxStageConfig(props: IStageConfigProps) {
             label="Sandbox ID"
             input={(props) => <TextInput {...props} />}
             help={<HelpField id="quali.colonyEndSandboxStage.sandboxId"/>}
+          />
+          <FormikFormField
+              name="token"
+              label="Token"
+              input={(props) => <TextInput {...props} />}
+              help={<HelpField id="quali.colonyStartSandboxStage.token"/>}
           />
           </>
         )}

--- a/colony-deck/src/ColonyStartSandboxStageConfig.tsx
+++ b/colony-deck/src/ColonyStartSandboxStageConfig.tsx
@@ -1,20 +1,14 @@
 import React from 'react';
 
 import {
-  ExecutionDetailsSection,
-  ExecutionDetailsTasks,
   FormikFormField,
   FormikStageConfig,
   FormValidator,
-  HelpContentsRegistry,
   HelpField,
-  IExecutionDetailsSectionProps,
   IStage,
   IStageConfigProps,
-  IStageTypeConfig,
   NumberInput,
   TextInput,
-  Validators,
 } from '@spinnaker/core';
 
 import './ColonyStartSandboxStage.less';

--- a/colony-deck/src/ColonyStartSandboxStageConfig.tsx
+++ b/colony-deck/src/ColonyStartSandboxStageConfig.tsx
@@ -72,7 +72,7 @@ export function ColonyStartSandboxStageConfig(props: IStageConfigProps) {
           <FormikFormField
               name="token"
               label="Token"
-              input={(props) => <TextInput {...props} />}
+              input={(props) => <TextInput type="password" {...props} />}
               help={<HelpField id="quali.colonyStartSandboxStage.token"/>}
               required={false}
           />

--- a/colony-deck/src/ColonyStartSandboxStageConfig.tsx
+++ b/colony-deck/src/ColonyStartSandboxStageConfig.tsx
@@ -69,12 +69,19 @@ export function ColonyStartSandboxStageConfig(props: IStageConfigProps) {
                   input={(props) => <NumberInput placeholder="20" value = '20' {...props} />}
                   help={<HelpField id="quali.colonyStartSandboxStage.timeout"/>}
           />
-              <FormikFormField
-                  name="duration"
-                  label="Duration (minutes)"
-                  input={(props) => <NumberInput placeholder="30" {...props} />}
-                  help={<HelpField id="quali.colonyStartSandboxStage.duration"/>}
-              />
+          <FormikFormField
+              name="duration"
+              label="Duration (minutes)"
+              input={(props) => <NumberInput placeholder="30" {...props} />}
+              help={<HelpField id="quali.colonyStartSandboxStage.duration"/>}
+          />
+          <FormikFormField
+              name="token"
+              label="Token"
+              input={(props) => <TextInput {...props} />}
+              help={<HelpField id="quali.colonyStartSandboxStage.token"/>}
+              required={false}
+          />
       </>
           )}
       />

--- a/colony-deck/src/initialize.ts
+++ b/colony-deck/src/initialize.ts
@@ -13,4 +13,6 @@ export const initialize = () => {
   HelpContentsRegistry.register('quali.colonyStartSandboxStage.timeout', 'Set the timeout in minutes for the sandbox to become active.');
   HelpContentsRegistry.register('quali.colonyEndSandboxStage.sandboxId', 'Specify sandbox ID. In most cases you will take it from Start Sandbox Stage context. Example: ${ #stage("Colony Start Sandbox")["outputs"]["sandboxId"]}');
   HelpContentsRegistry.register('quali.colonyEndSandboxStage.space', 'Colony Space Name (please use one from Start Sandbox Stage). Example: ${ #stage("Colony Start Sandbox")["context"]["space"]}');
+  HelpContentsRegistry.register('quali.colonyStartSandboxStage.token', 'Colony Token. Set, if you want to override token in config file');
+
 };

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/ColonyAuth.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/ColonyAuth.kt
@@ -3,11 +3,8 @@ package com.quali.colony.plugins.spinnaker
 import com.quali.colony.plugins.spinnaker.service.SandboxAPIServiceImpl
 import com.quali.colony.plugins.spinnaker.service.SandboxServiceConnection
 
-class ColonyAuth(private val config: ColonyConfig) {
+class ColonyAuth(private val token: String, private val url: String) {
     fun getAPI(): SandboxAPIServiceImpl {
-        val token = this.config.colonyToken
-        val url = this.config.colonyUrl
-
         val apiConnection = SandboxServiceConnection(url, token, 10, 30)
         // TODO(ddovbii) add some connection testing
         return SandboxAPIServiceImpl(apiConnection)

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/ColonyConfig.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/ColonyConfig.kt
@@ -12,7 +12,7 @@ import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 @PluginConfiguration
 
 data class ColonyConfig(
-        var colonyToken: String,
+        var colonyToken: String = "",
         var colonyUrl: String = "https://cloudshellcolony.com",
         var account: String = ""
 )

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyEndSandboxTask.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyEndSandboxTask.kt
@@ -28,8 +28,11 @@ class ColonyEndSandboxTask(private val config: ColonyConfig) : ColonyBaseTask {
         val token: String = ctx.token.ifEmpty {config.colonyToken }
 
         // if it's still empty fail the build
-        if (token.isEmpty())
-            throw IllegalArgumentException("The token was provided neither in the stage parameters nor in the config")
+        if (token.isEmpty()){
+            val errorMsg = "The token was provided neither in the stage parameters nor in the config"
+            addErrorMessage(stage, errorMsg)
+            throw IllegalArgumentException(errorMsg)
+        }
 
         val url = this.config.colonyUrl
         val api = ColonyAuth(token, url).getAPI()

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyStartSandboxTask.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyStartSandboxTask.kt
@@ -31,10 +31,10 @@ class ColonyStartSandboxTask(private val config: ColonyConfig) : ColonyBaseTask 
     private fun parseParamsString(paramsStr: String) : Map<String,String> {
         val holder = HashMap<String,String>()
 
-        if  ((paramsStr.trim().length > 0 ) || (paramsStr.contains("="))) {
-            val keyValues = paramsStr.split(", ")
+        if ((paramsStr.trim().isNotEmpty()) || (paramsStr.contains("="))) {
+            val keyValues = paramsStr.split(",")
             for (keyV in keyValues) {
-                val parts = keyV.split("=", limit = 2)
+                val parts = keyV.trim().split("=", limit = 2)
                 holder[parts[0]] = parts[1]
             }
         }

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyStartSandboxTask.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyStartSandboxTask.kt
@@ -22,7 +22,8 @@ class ColonyStartSandboxTask(private val config: ColonyConfig) : ColonyBaseTask 
             val duration: Int = 1,
             val timeoutMinutes: Int = 20,
             val artifacts: String = "",
-            val inputs: String = ""
+            val inputs: String = "",
+            val token: String = ""
     )
 
     private val log = LoggerFactory.getLogger(ColonyStartSandboxTask::class.java)
@@ -58,8 +59,11 @@ class ColonyStartSandboxTask(private val config: ColonyConfig) : ColonyBaseTask 
                 true,
                 inputs,
                 duration)
-
-        val api = ColonyAuth(config).getAPI()
+        
+        val token = ctx.token ?: config.colonyToken
+        val url = this.config.colonyUrl
+    
+        val api = ColonyAuth(token, url).getAPI()
         try {
             val res = api.createSandbox(ctx.space, startReq)
             return if (res.isSuccessful) {

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyStartSandboxTask.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyStartSandboxTask.kt
@@ -63,8 +63,12 @@ class ColonyStartSandboxTask(private val config: ColonyConfig) : ColonyBaseTask 
         val token: String = ctx.token.ifEmpty {config.colonyToken }
 
         // if it's still empty fail the build
-        if (token.isEmpty())
-            throw IllegalArgumentException("The token was provided neither in the stage parameters nor in the config")
+        if (token.isEmpty()) {
+            val errorMsg = "The token was provided neither in the stage parameters nor in the config"
+            addErrorMessage(stage, errorMsg)
+            throw IllegalArgumentException(errorMsg)
+        }
+
         this.addObjectToStageContext(stage, "token", token)
 
         val url = this.config.colonyUrl

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyVerifySandboxIsReadyTask.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyVerifySandboxIsReadyTask.kt
@@ -65,11 +65,14 @@ class ColonyVerifySandboxIsReadyTask(private val config: ColonyConfig) : ColonyB
         val sandboxId = stage.context["sandboxId"] as String
         val space = stage.context["space"] as String
         val timeoutMinutes = stage.context["timeoutMinutes"] as Int
-
+        val token = stage.context["token"] as String
+        val url = config.colonyUrl
+    
+        
         // Rewrite task timeout with user input
         taskTimeout = TimeUnit.MINUTES.toMillis(timeoutMinutes.toLong())
 
-        val api = ColonyAuth(config).getAPI()
+        val api = ColonyAuth(token, url).getAPI()
 
         log.info("Getting sandbox")
         val sandbox = api.getSandboxById(space, sandboxId)

--- a/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyVerifySandboxIsReadyTask.kt
+++ b/colony-orca/src/main/kotlin/com/quali/colony/plugins/spinnaker/tasks/ColonyVerifySandboxIsReadyTask.kt
@@ -67,8 +67,7 @@ class ColonyVerifySandboxIsReadyTask(private val config: ColonyConfig) : ColonyB
         val timeoutMinutes = stage.context["timeoutMinutes"] as Int
         val token = stage.context["token"] as String
         val url = config.colonyUrl
-    
-        
+
         // Rewrite task timeout with user input
         taskTimeout = TimeUnit.MINUTES.toMillis(timeoutMinutes.toLong())
 


### PR DESCRIPTION
- allow overriding token in start/end sandbox stages
- fix parsing of artifacts/inputs comma-separated line, allowing to put key-values pairs without spaces between them